### PR TITLE
Add Tooltip Pages/Scrolling To Avoid Text Runoff

### DIFF
--- a/core/src/main/java/io/masel/nbtviewer/core/listener/ItemStackTooltipListener.java
+++ b/core/src/main/java/io/masel/nbtviewer/core/listener/ItemStackTooltipListener.java
@@ -109,7 +109,8 @@ public class ItemStackTooltipListener {
 
     @Subscribe
     public void onMouseScroll(MouseScrollEvent event) {
-        if (!Laby.labyAPI().minecraft().isKeyPressed(Key.L_SHIFT))
+        if (!Laby.labyAPI().minecraft().isKeyPressed(Key.L_SHIFT) ||
+                !Laby.labyAPI().minecraft().minecraftWindow().isScreenOpened())
             return;
 
         event.setCancelled(true);

--- a/core/src/main/java/io/masel/nbtviewer/core/listener/ItemStackTooltipListener.java
+++ b/core/src/main/java/io/masel/nbtviewer/core/listener/ItemStackTooltipListener.java
@@ -4,14 +4,18 @@ import io.masel.nbtviewer.api.INBTApi;
 import io.masel.nbtviewer.core.NBTAddon;
 import net.labymod.api.Laby;
 import net.labymod.api.client.component.Component;
+import net.labymod.api.client.component.format.TextColor;
 import net.labymod.api.client.gui.screen.key.Key;
+import net.labymod.api.client.gui.window.Window;
 import net.labymod.api.client.world.item.ItemStack;
 import net.labymod.api.component.data.DataComponentContainer;
 import net.labymod.api.component.data.DataComponentKey;
 import net.labymod.api.component.data.NbtDataComponentContainer;
 import net.labymod.api.event.Subscribe;
+import net.labymod.api.event.client.input.MouseScrollEvent;
 import net.labymod.api.event.client.world.ItemStackTooltipEvent;
 import net.labymod.api.nbt.tags.NBTTagCompound;
+import net.labymod.api.util.Color;
 
 import javax.inject.Singleton;
 import java.util.List;
@@ -19,8 +23,16 @@ import java.util.List;
 @Singleton
 public class ItemStackTooltipListener {
 
+    private final Component barOpeningBracket = Component.text("[").color(TextColor.color(Color.DARK_GRAY.get()));
+    private final Component barClosingBracket = Component.text("]").color(TextColor.color(Color.DARK_GRAY.get()));
+    private final Component selectedPageIndicator = Component.text("▮").color(TextColor.color(Color.WHITE.get()));
+    private final Component pageSymbol = Component.text("·").color(TextColor.color(Color.LIGHT_GRAY.get()));
+
     private final NBTAddon nbtAddon;
     private final INBTApi nbtApi;
+
+    private int tooltipPage = 0;
+    private String lastTooltipId = "";
 
     public ItemStackTooltipListener(NBTAddon nbtAddon, INBTApi nbtApi) {
         this.nbtAddon = nbtAddon;
@@ -40,6 +52,13 @@ public class ItemStackTooltipListener {
         if (!itemStack.hasDataComponentContainer())
             return;
 
+        Window window = Laby.labyAPI().minecraft().minecraftWindow();
+
+        float guiScaleFloat = window.getScale();
+        int guiScale = Math.max(1, Math.round(guiScaleFloat));
+
+        int linesPerPage = Math.max(3, 45 / guiScale);
+
         DataComponentContainer components = itemStack.getDataComponentContainer();
 
         if (this.nbtAddon.configuration().isOnlyShowCustomData().getOrDefault(false)) {
@@ -48,22 +67,79 @@ public class ItemStackTooltipListener {
             if (!components.has(customDataKey))
                 return;
 
-            components = new NbtDataComponentContainer(((NBTTagCompound) components.get(customDataKey)));
+            components = new NbtDataComponentContainer((NBTTagCompound) components.get(customDataKey));
         }
 
-        List<Component> tooltipLines = event.getTooltipLines();
+        String id = itemStack.getAsItem().getIdentifier().getNamespace() + components.hashCode();
 
+        if (!id.equals(lastTooltipId)) {
+            tooltipPage = 0;
+            lastTooltipId = id;
+        }
+
+        String pretty = this.nbtApi.prettyPrint(components);
+
+        List<String> lines = List.of(pretty.split("\n"));
+        int totalPages = Math.max(1, (int) Math.ceil((double) lines.size() / linesPerPage));
+
+        tooltipPage = Math.min(tooltipPage, totalPages - 1);
+
+        List<Component> tooltipLines = event.getTooltipLines();
         tooltipLines.add(Component.empty());
 
-        String text = this.nbtApi.prettyPrint(components);
+        for (int i = tooltipPage * linesPerPage; i < Math.min(lines.size(), (tooltipPage + 1) * linesPerPage); i++) {
+            tooltipLines.add(Component.text(lines.get(i)));
+        }
 
-        for (String s : text.split("\n")) {
-            tooltipLines.add(Component.text(s));
+        if (totalPages > 1) {
+            tooltipLines.add(Component.empty());
+            tooltipLines.add(getPageBar(totalPages));
+            tooltipLines.add(Component.empty());
+
+            tooltipLines.add(
+                    Component.text("Page " + (tooltipPage + 1) + "/" + totalPages)
+                    .color(TextColor.color(Color.LIGHT_GRAY.get()))
+            );
         }
 
         if (this.nbtAddon.configuration().isCopy().getOrDefault(false)) {
-            Laby.labyAPI().minecraft().setClipboard(text);
+            Laby.labyAPI().minecraft().setClipboard(pretty);
         }
+    }
+
+    @Subscribe
+    public void onMouseScroll(MouseScrollEvent event) {
+        if (!Laby.labyAPI().minecraft().isKeyPressed(Key.L_SHIFT))
+            return;
+
+        event.setCancelled(true);
+
+        double scrollDelta = event.delta();
+
+        if (scrollDelta < 0) {
+            tooltipPage++;
+            return;
+        }
+
+        if (scrollDelta <= 0 || tooltipPage <= 0)
+            return;
+
+        tooltipPage--;
+    }
+
+    private Component getPageBar(int totalPages) {
+        Component bar = barOpeningBracket.copy();
+
+        for (int i = 0; i < totalPages; i++) {
+            if (i == tooltipPage) {
+                bar.append(selectedPageIndicator);
+                continue;
+            }
+
+            bar.append(pageSymbol);
+        }
+
+        return bar.append(barClosingBracket);
     }
 
 }


### PR DESCRIPTION
Adds support for paginating tooltip output to avoid text running off the screen.

- Enables Shift + Mouse Scroll to navigate pages

This allows users to view long tooltips (e.g. NBT data) without overflow.

**PREVIEW**

<table>
  <tr>
    <td><img width="220" alt="image" src="https://github.com/user-attachments/assets/a792940f-9dcf-4f0f-ae6b-b329cd048092" /></td>
    <td><img width="220" alt="image" src="https://github.com/user-attachments/assets/b259e0ac-476c-41cf-a96f-c0892073e9a0" /></td>
  </tr>
</table>
