### PR TITLE
develop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,17 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '25'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          validate-wrappers: true
+          cache-read-only: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build --full-stacktrace
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Artifacts
           path: build/libs/*-release.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 val versions = providers.gradleProperty("net.labymod.minecraft-versions").get().split(";")
 
 group = "io.masel"
-version = providers.environmentVariable("VERSION").getOrElse("3.2.0")
+version = providers.environmentVariable("VERSION").getOrElse("3.2.1")
 
 labyMod {
     defaultPackageName = "io.masel.nbtviewer"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,4 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb


### PR DESCRIPTION
- **chore: Update ci**
- **chore: Update Minecraft versions in gradle.properties**
- **feat: Add 26.1, 26.1.1 and 26.1.2 support**
- **chore: Bump version**
- **chore: Update JDK version from 21 to 25 in build configuration**
- **fix: Update ci pipelines**
- **chore: Bump version**
