### PR TITLE
Fix: Component.append() verwirft Rückgabewerte – Syntax-Highlighting und Seitenanzeige funktionieren nicht

### DIFF
--- a/api/src/main/java/io/masel/nbtviewer/api/JsonSyntaxHighlighter.java
+++ b/api/src/main/java/io/masel/nbtviewer/api/JsonSyntaxHighlighter.java
@@ -18,7 +18,7 @@ public class JsonSyntaxHighlighter {
         String indent = line.substring(0, line.length() - trimmed.length());
 
         if (!indent.isEmpty()) {
-            result.append(Component.text(indent));
+            result = result.append(Component.text(indent));
         }
 
         if (trimmed.isEmpty()) {
@@ -26,7 +26,7 @@ public class JsonSyntaxHighlighter {
         }
 
         if (isStructuralLine(trimmed)) {
-            result.append(Component.text(trimmed).color(colors.bracket()));
+            result = result.append(Component.text(trimmed).color(colors.bracket()));
             return result;
         }
 
@@ -34,13 +34,13 @@ public class JsonSyntaxHighlighter {
 
         if (colonIndex != -1) {
             String key = trimmed.substring(0, colonIndex);
-            result.append(Component.text(key).color(colors.key()));
-            result.append(Component.text(": ").color(colors.punctuation()));
+            result = result.append(Component.text(key).color(colors.key()));
+            result = result.append(Component.text(": ").color(colors.punctuation()));
 
             String valuePart = trimmed.substring(colonIndex + 2);
-            appendValue(result, valuePart, colors);
+            result = appendValue(result, valuePart, colors);
         } else {
-            appendValue(result, trimmed, colors);
+            result = appendValue(result, trimmed, colors);
         }
 
         return result;
@@ -81,7 +81,7 @@ public class JsonSyntaxHighlighter {
         return -1;
     }
 
-    private static void appendValue(Component result, String rawValue, SyntaxColors colors) {
+    private static Component appendValue(Component result, String rawValue, SyntaxColors colors) {
         boolean hasTrailingComma = rawValue.endsWith(",");
         String value = hasTrailingComma ? rawValue.substring(0, rawValue.length() - 1) : rawValue;
 
@@ -99,11 +99,13 @@ public class JsonSyntaxHighlighter {
             color = colors.string();
         }
 
-        result.append(Component.text(value).color(color));
+        result = result.append(Component.text(value).color(color));
 
         if (hasTrailingComma) {
-            result.append(Component.text(",").color(colors.punctuation()));
+            result = result.append(Component.text(",").color(colors.punctuation()));
         }
+
+        return result;
     }
 
     private static boolean isNumeric(String value) {

--- a/core/src/main/java/io/masel/nbtviewer/core/listener/ItemStackTooltipListener.java
+++ b/core/src/main/java/io/masel/nbtviewer/core/listener/ItemStackTooltipListener.java
@@ -187,11 +187,11 @@ public class ItemStackTooltipListener {
 
         for (int i = 0; i < totalPages; i++) {
             if (i == this.tooltipPage) {
-                bar.append(this.selectedPageIndicator);
+                bar = bar.append(this.selectedPageIndicator);
                 continue;
             }
 
-            bar.append(this.pageSymbol);
+            bar = bar.append(this.pageSymbol);
         }
 
         return bar.append(this.barClosingBracket);


### PR DESCRIPTION
## Problem

`net.labymod.api.client.component.Component` ist unveränderlich – `append()`
gibt ein neues Component zurück, verändert das Original aber nicht. An zwei
Stellen im Projekt wird der Rückgabewert von append() verworfen, wodurch die
jeweilige Funktion wirkungslos bleibt:

1. `JsonSyntaxHighlighter#highlightLine`: Alle append()-Aufrufe auf `result`
   ignorieren den Rückgabewert. Die Methode gibt dadurch immer
   `Component.empty()` zurück - die JSON-Syntax-Hervorhebung zeigt nie etwas an.

2. `ItemStackTooltipListener#getPageBar`: Die Seitenindikatoren (▮ / ·) werden
   in der Schleife an `bar` "angehängt", aber nie zurückgeschrieben. Die
   Seitenleiste zeigt am Ende nur die öffnende und schließende Klammer, ohne
   die eigentlichen Seiten-Symbole dazwischen.

## Fix

Beide Stellen weisen jetzt konsequent das Ergebnis von append() zurück
(`result = result.append(...)`), analog zum Rest des Projekts (siehe z. B.
die Verkettung in `ItemStackTooltipListener`, Zeile 137-142, die das
Rückgabemuster bereits korrekt nutzt). `appendValue()` in
JsonSyntaxHighlighter gibt jetzt ebenfalls das neue Component zurück statt
`void`.

## Geänderte Dateien

- api/src/main/java/io/masel/nbtviewer/api/JsonSyntaxHighlighter.java
- core/src/main/java/io/masel/nbtviewer/core/listener/ItemStackTooltipListener.java